### PR TITLE
Deploy key/value pair directly using deploy-key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ value of JSON key.
 
 If someone deploy the same JSON key, value pair, It adds comment on the issue.
 
+For deploying a single configuration, It supports `deploy-key` command.
+
+```console
+$ galbi deploy-key -k foo  -v bar
+...
+```
+
 ## How to get key?
 
 ```

--- a/galbi/cli.py
+++ b/galbi/cli.py
@@ -124,7 +124,7 @@ def deploy_kv_to_issue(
         'body': json.dumps(value),
     })
     resp.raise_for_status()
-    echo(f'"{key}" depoy done...')
+    echo(f'"{key}" deploy done...')
 
 
 @command()


### PR DESCRIPTION
Implement `deploy-key` command. It takes key/value pair, and then create a configuration from given key/value. So It makes you not to create a JSON file for a single configuration.