### PR TITLE
Uploade configuration to body of issue, not comment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Initialize galbi.
 ```
 
 
+## Migration
+
+In galbi 1.0, we changes a way to store a configuration.
+Before 1.0, galbi get a latest comment of issue to get body.
+But from galbi 1.0, It stores data in body of issue.
+
+So If you use galbi under 1.0 version, You need to migrate your configuration.
+
+```
+$ galbi migrate
+Are you sure you want to migrate galbi 0.2 to 1.0? [y/N]:
+```
+
+`migrate` command help you to migrate configurations.
+
+
 ## How to deploy key?
 
 It uploads JSON to reposotory's issue.
@@ -50,10 +66,12 @@ JSON key should be a title and label of issue.
 
 <img src="./images/issue_detail.png" />
 
-JSON value added to comment of the issue. Latest comment is the configuration
-value of JSON key.
+JSON value stored in body of the issue, and leaves a comment of the issue
+as well.
+If someone deploy the same JSON key, value pair, It updates a body and
+comment again.
 
-If someone deploy the same JSON key, value pair, It adds comment on the issue.
+Issue's comment is change log of configuration.
 
 For deploying a single configuration, It supports `deploy-key` command.
 
@@ -70,6 +88,14 @@ $ galbi get --key foo --key bar
     "foo": ...,
     "bar": ...,
 }
+```
+
+To get specific changes of configuration, you can use `get-rev` command.
+
+
+```
+$ galbi get-rev -k foo -r 0
+...
 ```
 
 Note that galbi only get a configuration from an opened issue.


### PR DESCRIPTION
Since GitHub comment API do not support sorting, It takes more time to
get latest comment of issue.

So I decided to update configuration on issue's body and leaves comments
as a revision of a configuration.

- `get-rev` command helps you to get the specific version of configuration (it starts with index 0).
- `migrate` command helps you to migrate older version of galbi to 1.0.